### PR TITLE
MC-34540: Invisible reCaptcha newsletter failure "Incorrect ReCaptcha…

### DIFF
--- a/Model/IsCheckRequired.php
+++ b/Model/IsCheckRequired.php
@@ -23,6 +23,7 @@ namespace MSP\ReCaptcha\Model;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class IsCheckRequired implements IsCheckRequiredInterface
 {
@@ -102,7 +103,8 @@ class IsCheckRequired implements IsCheckRequiredInterface
      */
     private function isZoneEnabled()
     {
-        return !$this->enableConfigFlag || $this->scopeConfig->getValue($this->enableConfigFlag);
+        return !$this->enableConfigFlag
+            || $this->scopeConfig->getValue($this->enableConfigFlag, ScopeInterface::SCOPE_WEBSITE);
     }
 
     /**


### PR DESCRIPTION
Since there are no automated tests for msp_recaptcha, the project is unsupported and archived, we can use this local team branch PR for CR.

Fix Summary: method isZoneEnabled() was checking if ReCaptcha for the particular zone (the area where it should be applied) was enabled on a global scope, and in the case of our bug - it was. However, it was disabled on the particular website scope and for that website, the ReCaptcha score evaluation code wasn't placed, but the score was expected for validation.